### PR TITLE
Update from OSI-450-a to OSI-450-a1. 

### DIFF
--- a/doc/icecap.tex
+++ b/doc/icecap.tex
@@ -498,7 +498,7 @@ This section controls which reference data is retrieved. Also it allows to selec
  \item \texttt{verdata}: determines which verification data is used. This can be 
  \begin{enumerate}
  	\item \texttt{osi-401-b}
- 	\item \texttt{osi-cdr}: this is a temporal combination of osi-450-a and osi-430-a
+ 	\item \texttt{osi-cdr}: this is a temporal combination of osi-450-a1 and osi-430-a
  \end{enumerate}
 As described, forecast data within \ice is always interpolated to the reference data grid. 
  
@@ -665,7 +665,7 @@ The following datasets are implemented in \ice.
 
 \begin{itemize}
 		\item \texttt{osi-401-b}
-		\item \texttt{osi-cdr}: this is a temporal combination of osi-450-a and osi-430-a
+		\item \texttt{osi-cdr}: this is a temporal combination of osi-450-a1 and osi-430-a
 \end{itemize}
 	
 \subsection{Forecast Datasets}

--- a/icecap/verdata.py
+++ b/icecap/verdata.py
@@ -14,7 +14,7 @@ xr.set_options(keep_attrs=True)
 
 params_verdata = {
     'sic' : {
-        'osi-450-a' : 'ice_conc',
+        'osi-450-a1' : 'ice_conc',
         'osi-401-b' : 'ice_conc',
         'osi-cdr' : 'ice_conc',
     }
@@ -28,7 +28,7 @@ def VerifData(conf):
     :return: Verification object
     """
     selector = {
-        'osi-450-a': _OSIThreddsRetrieval(conf),
+        'osi-450-a1': _OSIThreddsRetrieval(conf),
         'osi-401-b': _OSIThreddsRetrieval(conf),
         'osi-cdr': _OSIThreddsRetrieval(conf), # was osi-450-a_osi-430-a_mixed'
     }
@@ -64,9 +64,9 @@ class _OSIThreddsRetrieval(VerifyingData):
         self.dummydate = None
 
         self.root_server = "https://thredds.met.no/thredds/dodsC/osisaf/met.no/"
-        if self.verif_name == 'osi-450-a':
-            self.server = [self.root_server+"reprocessed/ice/conc_450a_files/"]
-            self.filebase = ["ice_conc_nh_ease2-250_cdr-v3p0_"]
+        if self.verif_name == 'osi-450-a1':
+            self.server = [self.root_server+"reprocessed/ice/conc_450a1_files/"]
+            self.filebase = ["ice_conc_nh_ease2-250_cdr-v3p1_"]
             self.fileext = ["1200.nc"]
 
             self.dummydate = '20171130'
@@ -80,8 +80,8 @@ class _OSIThreddsRetrieval(VerifyingData):
             self.dummydate = '20171130'
 
         if self.verif_name == 'osi-cdr':
-            self.server = self.root_server+"reprocessed/ice/conc_450a_files/"
-            self.filebase = "ice_conc_nh_ease2-250_cdr-v3p0_"
+            self.server = self.root_server+"reprocessed/ice/conc_450a1_files/"
+            self.filebase = "ice_conc_nh_ease2-250_cdr-v3p1_"
             self.fileext = "1200.nc"
 
             self.server = [self.server, self.root_server+"reprocessed/ice/conc_cra_files/"]


### PR DESCRIPTION
OSI-450-a1 is a bug-fix release of the 1978-2020 OSI SAF SIC CDR V3. See [OSI SAF webpage for announcement](https://osi-saf.eumetsat.int/community/list-of-service-messages/release-updated-version-sea-ice-concentration-climate-data).

