### PR TITLE
Fixes to documentation and environment

### DIFF
--- a/doc/icecap.tex
+++ b/doc/icecap.tex
@@ -307,7 +307,7 @@ This is an example how to run \ice on your local machine using a test configurat
 	\item Inspect graphic products.  \\
 	After the ecFlow suite has been run successfully the graphic products should be produced and can be inspected.
 	\begin{lstlisting}[language=bash]
-		$ cd scratchdir/topaz_test/plots/[metric-name]/
+		$ cd scratchdir/test_topaz/plots/[metric-name]/
 	\end{lstlisting}
 	
 \end{enumerate}

--- a/doc/icecap.tex
+++ b/doc/icecap.tex
@@ -280,7 +280,7 @@ This is an example how to run \ice on your local machine using a test configurat
 	
 	\item choose one configuration file from \texttt{ICECAP/conf/test} and copy it to your working directory. Two configuration files, which should run machine independent, are implemented. One using TOPAZ5 forecast data provided by MetNorway (\texttt{test\_topaz.conf}) and one using seasonal forecasts from the CDS (\texttt{test\_cds.conf}). Note that for the latter it is necessary to set up access to the CDS (see section \ref{subsec:cds})\\
 	\begin{lstlisting}[language=bash]
-		$ cp ICECAP/conf/test/icecap_topaz.conf icecap.conf
+		$ cp ICECAP/conf/test/test_topaz.conf icecap.conf
 	\end{lstlisting}
 	
 	\item Change the following settings in \texttt{icecap.conf} (All settings of the configuration file are described in detail in chapter \ref{chap:config}). 

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: %%ENVNAME%%
+name: icecap
 channels:
   - conda-forge
   - defaults


### PR DESCRIPTION
This PR addresses a few of @arnemelsom's comments in #3, namely points 2, 4, and 5. Point 2 caused an issue for me because the environment name could not be parsed by pixi when I wanted to create an environment with the environment.yml file:

```
$ pixi init --import environment.yml
Error:   × Failed to parse 'environment.yml' as a conda environment file
  ╰─▶ found character that cannot start any token at line 1 column 7, while scanning for the next token
   ╭─[environment.yml:1:7]
 1 │ name: %%ENVNAME%%
   ·       ┬
   ·       ╰── error occurred here
 2 │ channels:
   ╰────
```